### PR TITLE
Compare null newValue to undefined currentValue

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -106,11 +106,12 @@ async function main(organization: string, projectNumber: number, octokit: Pagina
         // Process each field, only updating if value has changed
         for (const [fieldName, fieldConfig] of Object.entries(REQUIRED_FIELDS)) {
             // A null newValue corresponds to undefined (cleared) currentValue
-            const newValue = (await fieldConfig.getValue(octokit, pr)) ?? undefined;
+            const newValue = (await fieldConfig.getValue(octokit, pr));
             const currentValue = existingItem?.fieldValues.get(fieldName);
             
-            // Compare values - handle different types appropriately
-            if ((newValue instanceof Date && currentValue instanceof Date) ? currentValue.getTime() === newValue.getTime() : currentValue === newValue) {
+            // Compare values - handle different types appropriately.
+            // A null newValue corresponds to an undefined currentValue
+            if ((newValue instanceof Date && currentValue instanceof Date) ? currentValue.getTime() === newValue.getTime() : currentValue === (newValue ?? undefined)) {
                 skippedCount++;
             } else {
                 console.log(`[${count} / ${openPRs.length}] Setting ${fieldName} to ${newValue} for ${pr.url}`);


### PR DESCRIPTION
Fixes #29

We want to keep the newValue as null (not undefined) since the field setting logic depends on it being null.