### PR TITLE
Rename gh-installation-id to gh-app-installation-id 

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -19,7 +19,7 @@ jobs:
           organization: 'jupyterhub'
           project-number: '4'
           gh-app-id: '1793875'
-          gh-installation-id: '81302562'
+          gh-app-installation-id: '81302562'
           gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   jupyterlab:
@@ -32,5 +32,5 @@ jobs:
           organization: 'jupyterlab'
           project-number: '11'
           gh-app-id: '1842581'
-          gh-installation-id: '82755492'
+          gh-app-installation-id: '82755492'
           gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_JUPYTERLAB }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ from 2i2c for context:
 
 3. Find the numerical app installation id for your organization. You can find
    this by looking at the last number in the URL for the installation settings - it would look
-   like `https://github.com/organizations/<organization>/settings/installations/<gh-installation-id>`
+   like `https://github.com/organizations/<organization>/settings/installations/<gh-app-installation-id>`
 
 ### Create the Project Board
 
@@ -59,7 +59,7 @@ npm install
 npm run build
 node dist/src/main.js \
   --gh-app-id <github-app-id> \
-  --gh-installation-id <github-installation-id> \
+  --gh-app-installation-id <github-installation-id> \
   --gh-app-pem-file <path-to-private-key> \
   [--repositories <repo1,repo2,repo3>] \
   <github-org-name> <github-project-id>
@@ -77,13 +77,11 @@ This should run for a bit and get you your project output!
 
 ## Using as a GitHub Action
 
-This repository now provides a GitHub Action that can be used in other organizations. Add the following to your workflow:
+This repository now provides a GitHub Action that can be used in workflows. To use this action:
 
-If the workflow is consolidating information from repo, it may make sense to have the workflow part of that repo. If the workflow is consolidating information across the org, you may consider running it in a centralized repo like the `.github` repo.
+1. Create an org-level secret using `Org Settings > Secrets and variables > Actions` with the contents of your app private key `.pem` file that was downloaded in the setup. We call this secret `GH_APP_PRIVATE_KEY` in our workflow below.
 
-1. Create an org-level secret using `Org Settings > Secrets and variables > Actions` with the contents of your app private key `.pem` file that was downloaded in the setup. We call this `GH_APP_PRIVATE_KEY` in our workflow below.
-
-2. Create a workflow file like the following to run the bot every hour and to be able to manually trigger a run:
+2. Create a workflow file like the following to run the bot every hour and to be able to manually trigger a run. If the workflow is consolidating information from multiple repos, consider having the workflow in a centralized repo like the orgs `.github` repo.
 
 
 ```yaml
@@ -105,7 +103,7 @@ jobs:
           organization: 'your-org-name'
           project-number: '1'
           gh-app-id: '12345'
-          gh-installation-id: '67890'
+          gh-app-installation-id: '67890'
           gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           repositories: 'repo1,repo2'  # Optional: limit to specific repos. Delete this line to default to all repos in the org
 ```
@@ -117,7 +115,7 @@ jobs:
 | `organization` | GitHub organization name | Yes | |
 | `project-number` | GitHub Project board number | Yes | |
 | `gh-app-id` | GitHub App ID for authentication | Yes | |
-| `gh-installation-id` | GitHub App Installation ID | Yes | |
+| `gh-app-installation-id` | GitHub App Installation ID | Yes | |
 | `gh-app-private-key` | GitHub App private key (PEM format) | Yes | |
 | `repositories` | Comma-separated list of repository names to limit querying to (optional) | No | |
 | `node-version` | Node.js version to use | No | `23.x` |

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ This repository now provides a GitHub Action that can be used in workflows. To u
 
 1. Create an org-level secret using `Org Settings > Secrets and variables > Actions` with the contents of your app private key `.pem` file that was downloaded in the setup. We call this secret `GH_APP_PRIVATE_KEY` in our workflow below.
 
-2. Create a workflow file like the following to run the bot every hour and to be able to manually trigger a run. If the workflow is consolidating information from multiple repos, consider having the workflow in a centralized repo like the orgs `.github` repo.
-
+2. Create a workflow file like the following to run the bot every hour and to be able to manually trigger a run. If you are consolidating PR information from multiple repos, consider creating the workflow in a centralized repo like the organization's `.github` repo.
 
 ```yaml
 name: 'PR Triage Bot'
@@ -117,7 +116,7 @@ jobs:
 | `gh-app-id` | GitHub App ID for authentication | Yes | |
 | `gh-app-installation-id` | GitHub App Installation ID | Yes | |
 | `gh-app-private-key` | GitHub App private key (PEM format) | Yes | |
-| `repositories` | Comma-separated list of repository names to limit querying to (optional) | No | |
+| `repositories` | Comma-separated list of repository names to limit querying (optional). If this is not specified, all repositories in the org will be queried. | No | |
 | `node-version` | Node.js version to use | No | `23.x` |
 
 ### Setting up the GitHub App

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   gh-app-id:
     description: 'GitHub App ID for authentication'
     required: true
-  gh-installation-id:
+  gh-app-installation-id:
     description: 'GitHub App Installation ID for authentication'
     required: true
   gh-app-private-key:
@@ -59,14 +59,14 @@ runs:
         if [ -n "${{ inputs.repositories }}" ]; then
           node dist/src/main.js \
             --gh-app-id ${{ inputs.gh-app-id }} \
-            --gh-installation-id ${{ inputs.gh-installation-id }} \
+            --gh-app-installation-id ${{ inputs.gh-app-installation-id }} \
             --gh-app-pem-file private-key.pem \
             --repositories "${{ inputs.repositories }}" \
             ${{ inputs.organization }} ${{ inputs.project-number }}
         else
           node dist/src/main.js \
             --gh-app-id ${{ inputs.gh-app-id }} \
-            --gh-installation-id ${{ inputs.gh-installation-id }} \
+            --gh-app-installation-id ${{ inputs.gh-app-installation-id }} \
             --gh-app-pem-file private-key.pem \
             ${{ inputs.organization }} ${{ inputs.project-number }}
         fi

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ async function main(organization: string, projectNumber: number, octokit: Pagina
 
 program
     .option("--gh-app-id <number>", "GitHub App ID to use for authentication", parseInt)
-    .option("--gh-installation-id <number>", "GitHub App Installation ID to use for authentication", parseInt)
+    .option("--gh-app-installation-id <number>", "GitHub App Installation ID to use for authentication", parseInt)
     .option("--gh-app-pem-file <string>", "Path to .pem file containing private key to use for authentication")
     .option("--repositories <repos>", "Comma-separated list of repository names to limit querying to (e.g., 'repo1,repo2')")
     .argument("<organization>")


### PR DESCRIPTION
We do this renaming to be consistent with other app inputs.

Also, tweak the readme action instructions to read better.