### PR TITLE
Run action commands inside of action_path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,18 @@ runs:
     - name: Install dependencies
       run: npm ci
       shell: bash
+      working-directory: ${{ github.action_path }}
 
     - name: Build project
       run: npm run build
       shell: bash
+      working-directory: ${{ github.action_path }}
 
     - name: Setup GitHub App Private Key
       run: |
         echo "${{ inputs.gh-app-private-key }}" > private-key.pem
       shell: bash
+      working-directory: ${{ github.action_path }}
 
     - name: Run PR Triage Bot
       run: |
@@ -71,8 +74,10 @@ runs:
             ${{ inputs.organization }} ${{ inputs.project-number }}
         fi
       shell: bash
+      working-directory: ${{ github.action_path }}
 
     - name: Cleanup private key
       run: rm -f private-key.pem
       shell: bash
       if: ${{ always() }}
+      working-directory: ${{ github.action_path }}


### PR DESCRIPTION
Apparently the action itself is checked out into github.action_path, so we need to do everything inside that dir.

@mfisher87, I think this should fix the errors on, for example https://github.com/geojupyter/jupytergis/actions/runs/17752300172/job/50449158016