### PR TITLE
Fix node setup caching

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -7,13 +7,16 @@ on:
   workflow_dispatch:  # Allows triggering manually from the UI
   push:
     branches: ["main"]
+  pull_request:
+    branches: [ "main" ]
+
 
 jobs:
   jupyterhub:
     runs-on: ubuntu-latest
     steps:
       - name: Run JupyterHub PR Triage Bot
-        uses: yuvipanda/pr-triage-board-bot@main
+        uses: ./
         with:
           organization: 'jupyterhub'
           project-number: '4'
@@ -25,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run JupyterLab PR Triage Bot
-        uses: yuvipanda/pr-triage-board-bot@main
+        uses: ./
         with:
           organization: 'jupyterlab'
           project-number: '11'

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch:  # Allows triggering manually from the UI
   push:
     branches: ["main"]
-  pull_request:
-    branches: [ "main" ]
 
 
 jobs:
@@ -16,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run JupyterHub PR Triage Bot
-        uses: ./
+        uses: yuvipanda/pr-triage-board-bot@main
         with:
           organization: 'jupyterhub'
           project-number: '4'
@@ -28,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run JupyterLab PR Triage Bot
-        uses: ./
+        uses: yuvipanda/pr-triage-board-bot@main
         with:
           organization: 'jupyterlab'
           project-number: '11'

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: ls
+      run: ls -la ${{ github.action_path }}
+      shell: bash
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: ls
-      run: ls -la ${{ github.action_path }}
+    # See https://github.com/actions/toolkit/issues/1035 for a discussion of why we need
+    # to copy package-lock.json to the WORKSPACE directory for npm caching to work. Basically,
+    # the hashFiles only works on files in the WORKSPACE directory.
+    - name: copy package-lock.json to WORKSPACE directory so the setup-node caching works
+      run: cp ${{ github.action_path }}/package-lock.json pr-triage-bot-package-lock.json
       shell: bash
 
     - name: Setup Node.js
@@ -44,7 +47,7 @@ runs:
       with:
         cache: 'npm'
         node-version: ${{ inputs.node-version }}
-        cache-dependency-path: ${{ github.action_path }}/package-lock.json
+        cache-dependency-path: pr-triage-bot-package-lock.json
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Copy the package-lock.json file to the workspace directory when running the action

This fixes a problem in the setup-node step, where the hashing for the npm cache only looks at files in the workspace directory. See https://github.com/actions/toolkit/issues/1035 for a discussion.

Fixes #37