### PR TITLE
Remove the JupyterLab cron job

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -21,15 +21,3 @@ jobs:
           gh-app-id: '1793875'
           gh-app-installation-id: '81302562'
           gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-  jupyterlab:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run JupyterLab PR Triage Bot
-        uses: yuvipanda/pr-triage-board-bot@main
-        with:
-          organization: 'jupyterlab'
-          project-number: '11'
-          gh-app-id: '1842581'
-          gh-app-installation-id: '82755492'
-          gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_JUPYTERLAB }}


### PR DESCRIPTION
We moved it into the JupyterLab org with https://github.com/jupyterlab/.github/pull/17, now that we have a composite action.